### PR TITLE
Bump version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-icons",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Custom icon font for Capital Framework.",
   "keywords": ["capital-framework", "capital", "icons", "less"],
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-icons",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Custom icon font for Capital Framework.",
   "keywords": ["capital-framework", "capital", "icons", "less"],
   "author": {


### PR DESCRIPTION
So, I couldn't get the Design Manual to load the latest cf-icons code
from master, and as such, I was unable to use the new `-round` suffixes.
I realized that bower will only install the most recent _tagged
snapshot_ of a package. So this PR bumps the version to 0.2.0, and I'll
push the corresponding tag for it as soon as this PR gets merged.
