### PR TITLE
New @import build process

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "bower_components"
+  "directory": "src/vendor"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,7 +100,7 @@ module.exports = function(grunt) {
   /**
    * Create custom task aliases for our component build workflow.
    */
-  grunt.registerTask('vendor', ['bower', 'copy:component_assets', 'copy:docs_assets', 'concat:main']);
-  grunt.registerTask('default', ['concat:main', 'less', 'autoprefixer', 'copy:docs', 'topdoc']);
+  grunt.registerTask('vendor', ['copy:component_assets', 'copy:docs_assets']);
+  grunt.registerTask('default', ['less', 'autoprefixer', 'copy:docs', 'topdoc']);
 
 };

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-icons",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "Custom icon font for Capital Framework.",
   "keywords": ["capital-framework", "capital", "icons", "less"],
   "authors": [
@@ -17,7 +17,7 @@
   "license": "https://github.com/cfpb/cf-icons/blob/gh-pages/TERMS.md",
   "main": "src/less/cf-icons.less",
   "dependencies": {
-    "cf-core": "latest"
+    "cf-core": "^1.0.0"
   },
   "exportsOverride": {
     "cf-*": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "posttest": "forever stopall -s"
   },
   "devDependencies": {
-    "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.9.1",
-    "cf-grunt-config": "~0.3.1",
+    "cf-component-demo": "^1.0.0",
+    "cf-grunt-config": "^1.0.0",
     "forever": "^0.14.1",
     "glob": "~4.3.2",
     "grunt": "~0.4.4",

--- a/src/cf-icons.less
+++ b/src/cf-icons.less
@@ -3,6 +3,7 @@
    Icons
    ========================================================================== */
 
+@import '../../cf-core/src/cf-core.less';
 
 /* topdoc
   name: Less variables
@@ -31,7 +32,7 @@
 */
 
 @cf-icon-prefix:                cf-icon;
-@cf-icon-path:                  '../fonts';
+@cf-icon-path:                  'fonts';
 @cf-icon-ie7-support:           true;
 @cf-icon-border-color:          #eee;
 


### PR DESCRIPTION
This implements the changes discussed in https://github.com/cfpb/capital-framework/issues/151.
## Removals
- Grunt bower and concat tasks
## Changes
- Font path is now relative.
- `bowerrc` points to `src/vendor` (the now-defunct Grunt task used to do this).
- Bumped to `1.0.0`.
## Testing
- You can't. :neutral_face: There's a chicken vs. the egg scenario here. This project's dependencies now point to the 1.x.x version of other CF components. But those versions aren't in Bower/npm yet because their PRs are still pending. This is why Travis is failing.
- The `dev` branch was thoroughly tested prior to this PR and more testing will occur afterward. There will likely be some kinks to work out after this merge but that's okay -- semver will shield current projects from any bugs.
## Review
- @Scotchester 
- @anselmbradford 
